### PR TITLE
Modified Crate File Checker to ignore files which don't end in .yml

### DIFF
--- a/src/me/BadBones69/CrazyCrates/SettingsManager.java
+++ b/src/me/BadBones69/CrazyCrates/SettingsManager.java
@@ -142,6 +142,9 @@ public class SettingsManager {
 	public ArrayList<File> getAllCrates() {
 		ArrayList<File> files = new ArrayList<File>();
 		for (String name : cratefolder.list()) {
+			if (!name.equalsIgnoreCase(name.substring(name.lastIndexOf('.') + 1, name.length()), "yml")) {
+				continue;
+			}
 			if (!name.equalsIgnoreCase(".DS_Store")) {
 				files.add(new File(cratefolder, name));
 			}
@@ -152,6 +155,9 @@ public class SettingsManager {
 	public ArrayList<String> getAllCratesNames() {
 		ArrayList<String> files = new ArrayList<String>();
 		for (String name : cratefolder.list()) {
+			if (!name.equalsIgnoreCase(name.substring(name.lastIndexOf('.') + 1, name.length()), "yml")) {
+				continue;
+			}
 			if (!name.equalsIgnoreCase(".DS_Store")) {
 				File f = new File(cratefolder, name);
 				files.add(f.getName().replaceAll(".yml", ""));


### PR DESCRIPTION
One of the bugs that we came across on our server was that if there were any files in the Crates folder, including lock files, this plugin would try to pull them in as a type of crate, leading to unpredictable behavior. This aims to fix that issue.