### PR TITLE
1.13 hotfix

### DIFF
--- a/crazycrates/pom.xml
+++ b/crazycrates/pom.xml
@@ -15,18 +15,28 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.8.2</version>
+            <version>2.9.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>be.maximvdw</groupId>
             <artifactId>MVdWPlaceholderAPI</artifactId>
-            <version>2.3.1-SNAPSHOT</version>
+            <version>2.5.2-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.spigotmc</groupId>
+                    <artifactId>spigot</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>be.maximvdw</groupId>
+                    <artifactId>MVdWUpdater</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
+            <artifactId>spigot-api</artifactId>
             <version>1.12.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
@@ -34,41 +44,55 @@
             <groupId>me.badbones69</groupId>
             <artifactId>v1_8_R1</artifactId>
             <version>1.8.3</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>me.badbones69</groupId>
             <artifactId>v1_8_R2</artifactId>
             <version>1.8.3</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>me.badbones69</groupId>
             <artifactId>v1_8_R3</artifactId>
             <version>1.8.3</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>me.badbones69</groupId>
             <artifactId>v1_9_R1</artifactId>
             <version>1.8.3</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>me.badbones69</groupId>
             <artifactId>v1_9_R2</artifactId>
             <version>1.8.3</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>me.badbones69</groupId>
             <artifactId>v1_10_R1</artifactId>
             <version>1.8.3</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>me.badbones69</groupId>
             <artifactId>v1_11_R1</artifactId>
             <version>1.8.3</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>me.badbones69</groupId>
             <artifactId>v1_12_R1</artifactId>
             <version>1.8.3</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>me.badbones69</groupId>
+            <artifactId>v1_13_R1</artifactId>
+            <version>1.8.3</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 
@@ -80,17 +104,6 @@
             </resource>
         </resources>
         <plugins>
-            <!-- Generates only the jar -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <id>default-jar</id>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- This disables the filtering in file extentions that can be corupted by it -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -104,17 +117,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.5</version>
-                <configuration>
-                    <artifactSet>
-                        <includes>
-                            <include>me.badbones69:*</include>
-                        </includes>
-                    </artifactSet>
-                    <!--<finalName>${project.artifactId}[v${project.version}]</finalName>-->
-                    <!--<outputFile>/Users/badbones/Desktop/Stuff/Server/plugins/${project.artifactId}[v${project.version}].jar</outputFile>-->
-                    <outputFile>/Users/badbones/Plugins/Public Plugins/Crazy Crates/${project.artifactId}[v${project.version}].jar</outputFile>
-                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/crazycrates/pom.xml
+++ b/crazycrates/pom.xml
@@ -94,6 +94,12 @@
             <version>1.8.3</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>me.badbones69</groupId>
+            <artifactId>v1_13_R2</artifactId>
+            <version>1.8.3</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/crazycrates/src/main/java/me/badbones69/crazycrates/Methods.java
+++ b/crazycrates/src/main/java/me/badbones69/crazycrates/Methods.java
@@ -7,6 +7,7 @@ import me.badbones69.crazycrates.controllers.FireworkDamageAPI;
 import me.badbones69.crazycrates.multisupport.Version;
 import me.badbones69.crazycrates.multisupport.itemnbtapi.NBTItem;
 import me.badbones69.crazycrates.multisupport.nms.*;
+import me.badbones69.crazycrates.multisupport.nms.v1_13_R1.NMS_v1_13_R1;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
@@ -33,19 +34,19 @@ import java.util.*;
 import java.util.logging.Level;
 
 public class Methods {
-	
+
 	private static CrazyCrates cc = CrazyCrates.getInstance();
 	public static HashMap<Player, String> path = new HashMap<>();
 	public static Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("CrazyCrates");
-	
+
 	public static String color(String msg) {
 		return ChatColor.translateAlternateColorCodes('&', msg);
 	}
-	
+
 	public static String removeColor(String msg) {
 		return ChatColor.stripColor(msg);
 	}
-	
+
 	public static HashMap<ItemStack, String> getItems(Player player) {
 		HashMap<ItemStack, String> items = new HashMap<>();
 		FileConfiguration file = cc.getOpeningCrate(player).getFile();
@@ -70,7 +71,7 @@ public class Methods {
 		}
 		return items;
 	}
-	
+
 	public static void fireWork(Location loc) {
 		final Firework fw = loc.getWorld().spawn(loc, Firework.class);
 		FireworkMeta fm = fw.getFireworkMeta();
@@ -80,7 +81,22 @@ public class Methods {
 		FireworkDamageAPI.addFirework(fw);
 		Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(plugin, fw::detonate, 2);
 	}
-	
+
+	private static Material fix113Material(String id, Material material) {
+        if(material == null) {
+            // 1.13 hotfix
+            switch (id) {
+                case "160":
+                    material = Material.getMaterial("STAINED_GLASS_PANE");
+                    break;
+            }
+            if(material == null) {
+                throw new IllegalArgumentException("Can't find material with id " + id);
+            }
+        }
+        return material;
+    }
+
 	public static ItemStack makeItem(Material material, int amount, int type, String name) {
 		ItemStack item = new ItemStack(material, amount, (short) type);
 		ItemMeta m = item.getItemMeta();
@@ -88,7 +104,7 @@ public class Methods {
 		item.setItemMeta(m);
 		return item;
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	public static ItemStack makeItem(String id, int amount, String name, List<String> lore) {
 		ArrayList<String> l = new ArrayList<>();
@@ -104,12 +120,16 @@ public class Methods {
 			}
 		}
 		Material m = Material.matchMaterial(id);
+        m = fix113Material(id, m);
 		if(m == Material.MOB_SPAWNER) {
 			ty = 0;
 		}
 		ItemStack item = new ItemStack(m, amount, (short) ty);
 		if(m == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R1:
+					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_12_R1:
 					item = NMS_v1_12_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -144,7 +164,7 @@ public class Methods {
 		}
 		return item;
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	public static ItemStack makeItem(String id, int amount, String name, List<String> lore, Boolean Enchanted) {
 		ArrayList<String> l = new ArrayList<>();
@@ -160,12 +180,16 @@ public class Methods {
 			}
 		}
 		Material m = Material.matchMaterial(id);
+        m = fix113Material(id, m);
 		if(m == Material.MOB_SPAWNER) {
 			ty = 0;
 		}
 		ItemStack item = new ItemStack(m, amount, (short) ty);
 		if(m == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R1:
+					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_12_R1:
 					item = NMS_v1_12_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -203,7 +227,7 @@ public class Methods {
 		}
 		return item;
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	public static ItemStack makeItem(String id, int amount, String name) {
 		int ty = 0;
@@ -218,12 +242,16 @@ public class Methods {
 			}
 		}
 		Material m = Material.matchMaterial(id);
+        m = fix113Material(id, m);
 		if(m == Material.MOB_SPAWNER) {
 			ty = 0;
 		}
 		ItemStack item = new ItemStack(m, amount, (short) ty);
 		if(m == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R1:
+					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_12_R1:
 					item = NMS_v1_12_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -255,7 +283,7 @@ public class Methods {
 		}
 		return item;
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	public static ItemStack makeItem(Material material, int amount, int ty, String name, List<String> lore) {
 		ArrayList<String> l = new ArrayList<>();
@@ -263,6 +291,9 @@ public class Methods {
 		ItemMeta m = item.getItemMeta();
 		if(material == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R1:
+					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_12_R1:
 					item = NMS_v1_12_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -289,7 +320,7 @@ public class Methods {
 		item.setItemMeta(m);
 		return item;
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	public static ItemStack makeItem(String id, int amount, String name, List<String> lore, Map<Enchantment, Integer> enchants) {
 		ArrayList<String> l = new ArrayList<>();
@@ -306,12 +337,16 @@ public class Methods {
 			}
 		}
 		Material material = Material.matchMaterial(type);
+        material = fix113Material(id, material);
 		if(material == Material.MOB_SPAWNER) {
 			ty = 0;
 		}
 		ItemStack item = new ItemStack(material, amount, (short) ty);
 		if(material == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R1:
+					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_12_R1:
 					item = NMS_v1_12_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -347,7 +382,7 @@ public class Methods {
 		}
 		return item;
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	public static ItemStack makeItem(String id, int amount, String name, List<String> lore, Map<Enchantment, Integer> enchants, Boolean glowing) {
 		ArrayList<String> l = new ArrayList<>();
@@ -364,12 +399,16 @@ public class Methods {
 			}
 		}
 		Material material = Material.matchMaterial(type);
+        material = fix113Material(id, material);
 		if(material == Material.MOB_SPAWNER) {
 			ty = 0;
 		}
 		ItemStack item = new ItemStack(material, amount, (short) ty);
 		if(material == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R1:
+					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_12_R1:
 					item = NMS_v1_12_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -408,13 +447,16 @@ public class Methods {
 		}
 		return item;
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	public static ItemStack makeItem(Material material, int amount, int ty, String name, List<String> lore, Map<Enchantment, Integer> enchants) {
 		ArrayList<String> l = new ArrayList<>();
 		ItemStack item = new ItemStack(material, amount, (short) ty);
 		if(material == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R1:
+					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_12_R1:
 					item = NMS_v1_12_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -443,7 +485,7 @@ public class Methods {
 		item.addUnsafeEnchantments(enchants);
 		return item;
 	}
-	
+
 	public static ItemStack makePlayerHead(String player, int amount, String name, ArrayList<String> lore, Map<Enchantment, Integer> enchants, boolean glowing) {
 		ItemStack head = new ItemStack(Material.SKULL_ITEM, 1, (short) 3);
 		ItemMeta m = head.getItemMeta();
@@ -470,7 +512,7 @@ public class Methods {
 		}
 		return nbtItem.getItem();
 	}
-	
+
 	public static ItemStack addLore(ItemStack item, String i) {
 		ArrayList<String> lore = new ArrayList<>();
 		ItemMeta m = item.getItemMeta();
@@ -482,7 +524,7 @@ public class Methods {
 		item.setItemMeta(m);
 		return item;
 	}
-	
+
 	public static PotionType getPotionType(PotionEffectType type) {
 		PotionType potionType = null;
 		if(type.equals(PotionEffectType.FIRE_RESISTANCE)) {
@@ -516,7 +558,7 @@ public class Methods {
 		}
 		return potionType;
 	}
-	
+
 	public static boolean isInt(String s) {
 		try {
 			Integer.parseInt(s);
@@ -525,11 +567,11 @@ public class Methods {
 		}
 		return true;
 	}
-	
+
 	public static Player getPlayer(String name) {
 		return Bukkit.getServer().getPlayer(name);
 	}
-	
+
 	public static boolean isOnline(String name, CommandSender sender) {
 		for(Player player : Bukkit.getServer().getOnlinePlayers()) {
 			if(player.getName().equalsIgnoreCase(name)) {
@@ -541,7 +583,7 @@ public class Methods {
 		sender.sendMessage(Messages.NOT_ONLINE.getMessage(placeholders));
 		return false;
 	}
-	
+
 	public static void removeItem(ItemStack item, Player player) {
 		try {
 			if(item.getAmount() <= 1) {
@@ -552,7 +594,7 @@ public class Methods {
 		}catch(Exception e) {
 		}
 	}
-	
+
 	public static void removeItem(ItemStack item, Player player, int amount) {
 		try {
 			int left = amount;
@@ -575,7 +617,7 @@ public class Methods {
 		}catch(Exception e) {
 		}
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	public static ItemStack getItemInHand(Player player) {
 		if(Version.getCurrentVersion().getCurrentVersionInteger() >= Version.v1_9_R1.getCurrentVersionInteger()) {
@@ -584,7 +626,7 @@ public class Methods {
 			return player.getItemInHand();
 		}
 	}
-	
+
 	@SuppressWarnings("deprecation")
 	public static void setItemInHand(Player player, ItemStack item) {
 		if(Version.getCurrentVersion().getCurrentVersionInteger() >= Version.v1_9_R1.getCurrentVersionInteger()) {
@@ -593,7 +635,7 @@ public class Methods {
 			player.setItemInHand(item);
 		}
 	}
-	
+
 	public static boolean permCheck(Player player, String perm) {
 		if(!player.hasPermission("crazycrates." + perm.toLowerCase())) {
 			player.sendMessage(Messages.NO_PERMISSION.getMessage());
@@ -601,19 +643,22 @@ public class Methods {
 		}
 		return true;
 	}
-	
+
 	public static String getPrefix() {
 		return color(Files.CONFIG.getFile().getString("Settings.Prefix"));
 	}
-	
+
 	public static String getPrefix(String msg) {
 		return color(Files.CONFIG.getFile().getString("Settings.Prefix") + msg);
 	}
-	
+
 	public static void pasteSchem(String schem, Location loc) {
 		switch(Version.getCurrentVersion()) {
 			case TOO_NEW:
 				Bukkit.getLogger().log(Level.SEVERE, "[Crazy Crates]>> Your server is too new for this plugin. " + "Please update or remove this plugin to stop further Errors.");
+				break;
+			case v1_13_R1:
+				NMS_v1_13_R1.pasteSchematic(new File(plugin.getDataFolder() + "/Schematics/" + schem), loc);
 				break;
 			case v1_12_R1:
 				NMS_v1_12_R1.pasteSchematic(new File(plugin.getDataFolder() + "/Schematics/" + schem), loc);
@@ -646,12 +691,14 @@ public class Methods {
 				break;
 		}
 	}
-	
+
 	public static List<Location> getLocations(String shem, Location loc) {
 		switch(Version.getCurrentVersion()) {
 			case TOO_NEW:
 				Bukkit.getLogger().log(Level.SEVERE, "[Crazy Crates]>> Your server is too new for this plugin. " + "Please update or remove this plugin to stop further Errors.");
 				break;
+			case v1_13_R1:
+				return NMS_v1_13_R1.getLocations(new File(plugin.getDataFolder() + "/Schematics/" + shem), loc);
 			case v1_12_R1:
 				return NMS_v1_12_R1.getLocations(new File(plugin.getDataFolder() + "/Schematics/" + shem), loc);
 			case v1_11_R1:
@@ -676,7 +723,7 @@ public class Methods {
 		}
 		return null;
 	}
-	
+
 	public static void playChestAction(Block b, boolean open) {
 		Location location = b.getLocation();
 		Material type = b.getType();
@@ -684,6 +731,9 @@ public class Methods {
 			switch(Version.getCurrentVersion()) {
 				case TOO_NEW:
 					Bukkit.getLogger().log(Level.SEVERE, "[Crazy Crates]>> Your server is too new for this plugin. " + "Please update or remove this plugin to stop further Errors.");
+					break;
+				case v1_13_R1:
+					NMS_v1_13_R1.openChest(b, location, open);
 					break;
 				case v1_12_R1:
 					NMS_v1_12_R1.openChest(b, location, open);
@@ -717,9 +767,11 @@ public class Methods {
 			}
 		}
 	}
-	
+
 	public static ItemStack addGlow(ItemStack item) {
 		switch(Version.getCurrentVersion()) {
+			case v1_13_R1:
+				return NMS_v1_13_R1.addGlow(item);
 			case v1_12_R1:
 				return NMS_v1_12_R1.addGlow(item);
 			case v1_11_R1:
@@ -741,9 +793,11 @@ public class Methods {
 		}
 		return item;
 	}
-	
+
 	public static ItemStack addUnbreaking(ItemStack item) {
 		switch(Version.getCurrentVersion()) {
+			case v1_13_R1:
+				return NMS_v1_13_R1.addUnbreaking(item);
 			case v1_12_R1:
 				return NMS_v1_12_R1.addUnbreaking(item);
 			case v1_11_R1:
@@ -759,10 +813,12 @@ public class Methods {
 		}
 		return item;
 	}
-	
+
 	public static ItemStack addUnbreaking(ItemStack item, Boolean toggle) {
 		if(toggle) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R1:
+					return NMS_v1_12_R1.addUnbreaking(item);
 				case v1_12_R1:
 					return NMS_v1_12_R1.addUnbreaking(item);
 				case v1_11_R1:
@@ -779,7 +835,7 @@ public class Methods {
 		}
 		return item;
 	}
-	
+
 	public static String pickRandomSchem() {
 		File f = new File(plugin.getDataFolder() + "/Schematics/");
 		String[] schems = f.list();
@@ -792,16 +848,16 @@ public class Methods {
 		Random r = new Random();
 		return schematics.get(r.nextInt(schematics.size()));
 	}
-	
+
 	public static boolean isInventoryFull(Player player) {
 		return player.getInventory().firstEmpty() == -1;
 	}
-	
+
 	public static Integer randomNumber(int min, int max) {
 		Random i = new Random();
 		return min + i.nextInt(max - min);
 	}
-	
+
 	public static boolean isSimilar(ItemStack one, ItemStack two) {
 		if(one != null && two != null) {
 			if(one.getType() == two.getType()) {
@@ -842,7 +898,7 @@ public class Methods {
 		}
 		return false;
 	}
-	
+
 	public static void hasUpdate() {
 		try {
 			HttpURLConnection c = (HttpURLConnection) new URL("http://www.spigotmc.org/api/general.php").openConnection();
@@ -857,7 +913,7 @@ public class Methods {
 		}catch(Exception e) {
 		}
 	}
-	
+
 	public static void hasUpdate(Player player) {
 		try {
 			HttpURLConnection c = (HttpURLConnection) new URL("http://www.spigotmc.org/api/general.php").openConnection();
@@ -872,7 +928,7 @@ public class Methods {
 		}catch(Exception e) {
 		}
 	}
-	
+
 	public static Set<String> getEnchantments() {
 		HashMap<String, String> enchants = new HashMap<>();
 		enchants.put("ARROW_DAMAGE", "Power");
@@ -906,7 +962,7 @@ public class Methods {
 		enchants.put("VANISHING_CURSE", "Curse_Of_Vanishing");
 		return enchants.keySet();
 	}
-	
+
 	public static String getEnchantmentName(Enchantment en) {
 		HashMap<String, String> enchants = new HashMap<>();
 		enchants.put("ARROW_DAMAGE", "Power");
@@ -943,5 +999,5 @@ public class Methods {
 		}
 		return enchants.get(en.getName());
 	}
-	
+
 }

--- a/crazycrates/src/main/java/me/badbones69/crazycrates/Methods.java
+++ b/crazycrates/src/main/java/me/badbones69/crazycrates/Methods.java
@@ -7,7 +7,8 @@ import me.badbones69.crazycrates.controllers.FireworkDamageAPI;
 import me.badbones69.crazycrates.multisupport.Version;
 import me.badbones69.crazycrates.multisupport.itemnbtapi.NBTItem;
 import me.badbones69.crazycrates.multisupport.nms.*;
-import me.badbones69.crazycrates.multisupport.nms.v1_13_R1.NMS_v1_13_R1;
+import me.badbones69.crazycrates.multisupport.nms.v1_13_R2.NMS_v1_13_R1;
+import me.badbones69.crazycrates.multisupport.nms.v1_13_R2.NMS_v1_13_R2;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
@@ -127,6 +128,9 @@ public class Methods {
 		ItemStack item = new ItemStack(m, amount, (short) ty);
 		if(m == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R2:
+					item = NMS_v1_13_R2.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_13_R1:
 					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -187,6 +191,9 @@ public class Methods {
 		ItemStack item = new ItemStack(m, amount, (short) ty);
 		if(m == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R2:
+					item = NMS_v1_13_R2.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_13_R1:
 					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -249,6 +256,9 @@ public class Methods {
 		ItemStack item = new ItemStack(m, amount, (short) ty);
 		if(m == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R2:
+					item = NMS_v1_13_R2.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_13_R1:
 					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -291,6 +301,9 @@ public class Methods {
 		ItemMeta m = item.getItemMeta();
 		if(material == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R2:
+					item = NMS_v1_13_R2.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_13_R1:
 					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -344,6 +357,9 @@ public class Methods {
 		ItemStack item = new ItemStack(material, amount, (short) ty);
 		if(material == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R2:
+					item = NMS_v1_13_R2.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_13_R1:
 					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -406,6 +422,9 @@ public class Methods {
 		ItemStack item = new ItemStack(material, amount, (short) ty);
 		if(material == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R2:
+					item = NMS_v1_13_R2.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_13_R1:
 					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -454,6 +473,9 @@ public class Methods {
 		ItemStack item = new ItemStack(material, amount, (short) ty);
 		if(material == Material.MONSTER_EGG) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R2:
+					item = NMS_v1_13_R2.getSpawnEgg(EntityType.fromId(ty), amount);
+					break;
 				case v1_13_R1:
 					item = NMS_v1_13_R1.getSpawnEgg(EntityType.fromId(ty), amount);
 					break;
@@ -657,6 +679,9 @@ public class Methods {
 			case TOO_NEW:
 				Bukkit.getLogger().log(Level.SEVERE, "[Crazy Crates]>> Your server is too new for this plugin. " + "Please update or remove this plugin to stop further Errors.");
 				break;
+			case v1_13_R2:
+				NMS_v1_13_R2.pasteSchematic(new File(plugin.getDataFolder() + "/Schematics/" + schem), loc);
+				break;
 			case v1_13_R1:
 				NMS_v1_13_R1.pasteSchematic(new File(plugin.getDataFolder() + "/Schematics/" + schem), loc);
 				break;
@@ -697,6 +722,8 @@ public class Methods {
 			case TOO_NEW:
 				Bukkit.getLogger().log(Level.SEVERE, "[Crazy Crates]>> Your server is too new for this plugin. " + "Please update or remove this plugin to stop further Errors.");
 				break;
+			case v1_13_R2:
+				return NMS_v1_13_R2.getLocations(new File(plugin.getDataFolder() + "/Schematics/" + shem), loc);
 			case v1_13_R1:
 				return NMS_v1_13_R1.getLocations(new File(plugin.getDataFolder() + "/Schematics/" + shem), loc);
 			case v1_12_R1:
@@ -731,6 +758,9 @@ public class Methods {
 			switch(Version.getCurrentVersion()) {
 				case TOO_NEW:
 					Bukkit.getLogger().log(Level.SEVERE, "[Crazy Crates]>> Your server is too new for this plugin. " + "Please update or remove this plugin to stop further Errors.");
+					break;
+				case v1_13_R2:
+					NMS_v1_13_R2.openChest(b, location, open);
 					break;
 				case v1_13_R1:
 					NMS_v1_13_R1.openChest(b, location, open);
@@ -770,6 +800,8 @@ public class Methods {
 
 	public static ItemStack addGlow(ItemStack item) {
 		switch(Version.getCurrentVersion()) {
+			case v1_13_R2:
+				return NMS_v1_13_R2.addGlow(item);
 			case v1_13_R1:
 				return NMS_v1_13_R1.addGlow(item);
 			case v1_12_R1:
@@ -796,6 +828,8 @@ public class Methods {
 
 	public static ItemStack addUnbreaking(ItemStack item) {
 		switch(Version.getCurrentVersion()) {
+			case v1_13_R2:
+				return NMS_v1_13_R2.addUnbreaking(item);
 			case v1_13_R1:
 				return NMS_v1_13_R1.addUnbreaking(item);
 			case v1_12_R1:
@@ -817,8 +851,10 @@ public class Methods {
 	public static ItemStack addUnbreaking(ItemStack item, Boolean toggle) {
 		if(toggle) {
 			switch(Version.getCurrentVersion()) {
+				case v1_13_R2:
+					return NMS_v1_13_R2.addUnbreaking(item);
 				case v1_13_R1:
-					return NMS_v1_12_R1.addUnbreaking(item);
+					return NMS_v1_13_R1.addUnbreaking(item);
 				case v1_12_R1:
 					return NMS_v1_12_R1.addUnbreaking(item);
 				case v1_11_R1:

--- a/crazycrates/src/main/java/me/badbones69/crazycrates/multisupport/Version.java
+++ b/crazycrates/src/main/java/me/badbones69/crazycrates/multisupport/Version.java
@@ -11,6 +11,7 @@ public enum Version {
 	v1_10_R1(1101),
 	v1_11_R1(1111),
 	v1_12_R1(1121),
+	v1_13_R1(1130),
 	TOO_NEW(-2);
 	
 	private static Version latest;

--- a/crazycrates/src/main/java/me/badbones69/crazycrates/multisupport/Version.java
+++ b/crazycrates/src/main/java/me/badbones69/crazycrates/multisupport/Version.java
@@ -12,6 +12,7 @@ public enum Version {
 	v1_11_R1(1111),
 	v1_12_R1(1121),
 	v1_13_R1(1130),
+	v1_13_R2(1131),
 	TOO_NEW(-2);
 	
 	private static Version latest;

--- a/pom.xml
+++ b/pom.xml
@@ -18,34 +18,98 @@
         <module>v1_10_R1</module>
         <module>v1_11_R1</module>
         <module>v1_12_R1</module>
+        <module>v1_13_R1</module>
         <module>crazycrates</module>
     </modules>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <build>
-        <defaultGoal>clean install package</defaultGoal>
+        <defaultGoal>clean package</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <show>public</show>
+                    <failOnError>false</failOnError>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>2.5.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+            </plugin>
         </plugins>
     </build>
 
     <repositories>
         <repository>
-            <id>mvdw-software</id>
-            <name>MVdW Public Repositories</name>
+            <id>spigotmc-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>mvdw-repo</id>
             <url>http://repo.mvdw-software.be/content/groups/public/</url>
         </repository>
         <repository>
-            <id>placeholderapi</id>
+            <id>placeholderapi-repo</id>
             <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>nms-repo</id>
+            <url>https://repo.codemc.org/repository/nms/</url>
+        </repository>
     </repositories>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>v1_11_R1</module>
         <module>v1_12_R1</module>
         <module>v1_13_R1</module>
+        <module>v1_13_R2</module>
         <module>crazycrates</module>
     </modules>
 
@@ -43,7 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -76,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.0</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>

--- a/v1_13_R1/pom.xml
+++ b/v1_13_R1/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>me.badbones69</groupId>
+        <artifactId>crazycrates-parent</artifactId>
+        <version>1.8.3</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>v1_13_R1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.13-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/v1_13_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R1/NMS_v1_13_R1.java
+++ b/v1_13_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R1/NMS_v1_13_R1.java
@@ -1,0 +1,139 @@
+package me.badbones69.crazycrates.multisupport.nms.v1_13_R1;
+
+import net.minecraft.server.v1_13_R1.*;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_13_R1.inventory.CraftItemStack;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class NMS_v1_13_R1 {
+
+	public static ItemStack addUnbreaking(ItemStack item) {
+		net.minecraft.server.v1_13_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+		NBTTagCompound tag = null;
+		if(!nmsStack.hasTag()) {
+			tag = new NBTTagCompound();
+			nmsStack.setTag(tag);
+		}
+		if(tag == null) {
+			tag = nmsStack.getTag();
+		}
+		tag.setBoolean("Unbreakable", true);
+		tag.setInt("HideFlags", 4);
+		nmsStack.setTag(tag);
+		return CraftItemStack.asCraftMirror(nmsStack);
+	}
+
+	public static ItemStack addGlow(ItemStack item) {
+		if(item != null) {
+			if(item.hasItemMeta()) {
+				if(item.getItemMeta().hasEnchants()) {
+					return item;
+				}
+			}
+			item.addUnsafeEnchantment(Enchantment.LUCK, 1);
+			ItemMeta meta = item.getItemMeta();
+			meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+			item.setItemMeta(meta);
+		}
+		return item;
+	}
+
+	public static ItemStack getInHand(Player player) {
+		return player.getInventory().getItemInMainHand();
+	}
+
+	public static void openChest(Block b, Location location, Boolean open) {
+		World world = ((org.bukkit.craftbukkit.v1_13_R1.CraftWorld) location.getWorld()).getHandle();
+		BlockPosition position = new BlockPosition(location.getX(), location.getY(), location.getZ());
+		if(b.getType() == Material.ENDER_CHEST) {
+			TileEntityEnderChest tileChest = (TileEntityEnderChest) world.getTileEntity(position);
+			world.playBlockAction(position, tileChest.getBlock().getBlock(), 1, open ? 1 : 0);
+		}else {
+			TileEntityChest tileChest = (TileEntityChest) world.getTileEntity(position);
+			world.playBlockAction(position, tileChest.getBlock().getBlock(), 1, open ? 1 : 0);
+		}
+	}
+
+	// http://stackoverflow.com/questions/24101928/setting-block-data-from-schematic-in-bukkit
+	@SuppressWarnings("deprecation")
+	public static List<Location> pasteSchematic(File f, Location loc) {
+		/* FIXME: implement 1.13 schematics
+		loc = loc.subtract(2, 1, 2);
+		List<Location> locations = new ArrayList<>();
+		try {
+			FileInputStream fis = new FileInputStream(f);
+			NBTTagCompound nbt = NBTCompressedStreamTools.a(fis);
+			short width = nbt.getShort("Width");
+			short height = nbt.getShort("Height");
+			short length = nbt.getShort("Length");
+			byte[] blocks = nbt.getByteArray("Blocks");
+			byte[] data = nbt.getByteArray("Data");
+			fis.close();
+			//paste
+			for(int x = 0; x < width; ++x) {
+				for(int y = 0; y < height; ++y) {
+					for(int z = 0; z < length; ++z) {
+						int index = y * width * length + z * width + x;
+						final Location l = new Location(loc.getWorld(), x + loc.getX(), y + loc.getY(), z + loc.getZ());
+						int b = blocks[index] & 0xFF;//make the block unsigned, so that blocks with an id over 127, like quartz and emerald, can be pasted
+						final Block block = l.getBlock();
+						Material m = Material.getMaterial(b);
+						block.setType(m);
+						block.setData(data[index]);
+						//you can check what type the block is here, like if(m.equals(Material.BEACON)) to check if it's a beacon        
+						locations.add(l);
+					}
+				}
+			}
+		}catch(Exception e) {
+			e.printStackTrace();
+		}
+		return locations;
+		*/
+		return Collections.emptyList();
+	}
+
+	public static List<Location> getLocations(File f, Location loc) {
+		loc = loc.subtract(2, 1, 2);
+		List<Location> locations = new ArrayList<>();
+		try {
+			FileInputStream fis = new FileInputStream(f);
+			NBTTagCompound nbt = NBTCompressedStreamTools.a(fis);
+			short width = nbt.getShort("Width");
+			short height = nbt.getShort("Height");
+			short length = nbt.getShort("Length");
+			fis.close();
+			//paste
+			for(int x = 0; x < width; ++x) {
+				for(int y = 0; y < height; ++y) {
+					for(int z = 0; z < length; ++z) {
+						final Location l = new Location(loc.getWorld(), x + loc.getX(), y + loc.getY(), z + loc.getZ());
+						locations.add(l);
+					}
+				}
+			}
+		}catch(Exception e) {
+			e.printStackTrace();
+		}
+		return locations;
+	}
+
+	@SuppressWarnings("deprecation")
+	public static ItemStack getSpawnEgg(EntityType type, int amount) {
+		return new ItemStack(Material.getMaterial(type.name() + "_SPAWN_EGG"), amount);
+	}
+
+}

--- a/v1_13_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R2/NMS_v1_13_R1.java
+++ b/v1_13_R1/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R2/NMS_v1_13_R1.java
@@ -1,4 +1,4 @@
-package me.badbones69.crazycrates.multisupport.nms.v1_13_R1;
+package me.badbones69.crazycrates.multisupport.nms.v1_13_R2;
 
 import net.minecraft.server.v1_13_R1.*;
 import org.bukkit.Location;

--- a/v1_13_R2/pom.xml
+++ b/v1_13_R2/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>me.badbones69</groupId>
+        <artifactId>crazycrates-parent</artifactId>
+        <version>1.8.3</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>v1_13_R2</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.13.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/v1_13_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R2/NMS_v1_13_R2.java
+++ b/v1_13_R2/src/main/java/me/badbones69/crazycrates/multisupport/nms/v1_13_R2/NMS_v1_13_R2.java
@@ -1,0 +1,139 @@
+package me.badbones69.crazycrates.multisupport.nms.v1_13_R2;
+
+import net.minecraft.server.v1_13_R2.*;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.craftbukkit.v1_13_R2.inventory.CraftItemStack;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class NMS_v1_13_R2 {
+
+	public static ItemStack addUnbreaking(ItemStack item) {
+		net.minecraft.server.v1_13_R2.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+		NBTTagCompound tag = null;
+		if(!nmsStack.hasTag()) {
+			tag = new NBTTagCompound();
+			nmsStack.setTag(tag);
+		}
+		if(tag == null) {
+			tag = nmsStack.getTag();
+		}
+		tag.setBoolean("Unbreakable", true);
+		tag.setInt("HideFlags", 4);
+		nmsStack.setTag(tag);
+		return CraftItemStack.asCraftMirror(nmsStack);
+	}
+
+	public static ItemStack addGlow(ItemStack item) {
+		if(item != null) {
+			if(item.hasItemMeta()) {
+				if(item.getItemMeta().hasEnchants()) {
+					return item;
+				}
+			}
+			item.addUnsafeEnchantment(Enchantment.LUCK, 1);
+			ItemMeta meta = item.getItemMeta();
+			meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+			item.setItemMeta(meta);
+		}
+		return item;
+	}
+
+	public static ItemStack getInHand(Player player) {
+		return player.getInventory().getItemInMainHand();
+	}
+
+	public static void openChest(Block b, Location location, Boolean open) {
+		World world = ((org.bukkit.craftbukkit.v1_13_R2.CraftWorld) location.getWorld()).getHandle();
+		BlockPosition position = new BlockPosition(location.getX(), location.getY(), location.getZ());
+		if(b.getType() == Material.ENDER_CHEST) {
+			TileEntityEnderChest tileChest = (TileEntityEnderChest) world.getTileEntity(position);
+			world.playBlockAction(position, tileChest.getBlock().getBlock(), 1, open ? 1 : 0);
+		}else {
+			TileEntityChest tileChest = (TileEntityChest) world.getTileEntity(position);
+			world.playBlockAction(position, tileChest.getBlock().getBlock(), 1, open ? 1 : 0);
+		}
+	}
+
+	// http://stackoverflow.com/questions/24101928/setting-block-data-from-schematic-in-bukkit
+	@SuppressWarnings("deprecation")
+	public static List<Location> pasteSchematic(File f, Location loc) {
+		/* FIXME: implement 1.13 schematics
+		loc = loc.subtract(2, 1, 2);
+		List<Location> locations = new ArrayList<>();
+		try {
+			FileInputStream fis = new FileInputStream(f);
+			NBTTagCompound nbt = NBTCompressedStreamTools.a(fis);
+			short width = nbt.getShort("Width");
+			short height = nbt.getShort("Height");
+			short length = nbt.getShort("Length");
+			byte[] blocks = nbt.getByteArray("Blocks");
+			byte[] data = nbt.getByteArray("Data");
+			fis.close();
+			//paste
+			for(int x = 0; x < width; ++x) {
+				for(int y = 0; y < height; ++y) {
+					for(int z = 0; z < length; ++z) {
+						int index = y * width * length + z * width + x;
+						final Location l = new Location(loc.getWorld(), x + loc.getX(), y + loc.getY(), z + loc.getZ());
+						int b = blocks[index] & 0xFF;//make the block unsigned, so that blocks with an id over 127, like quartz and emerald, can be pasted
+						final Block block = l.getBlock();
+						Material m = Material.getMaterial(b);
+						block.setType(m);
+						block.setData(data[index]);
+						//you can check what type the block is here, like if(m.equals(Material.BEACON)) to check if it's a beacon        
+						locations.add(l);
+					}
+				}
+			}
+		}catch(Exception e) {
+			e.printStackTrace();
+		}
+		return locations;
+		*/
+		return Collections.emptyList();
+	}
+
+	public static List<Location> getLocations(File f, Location loc) {
+		loc = loc.subtract(2, 1, 2);
+		List<Location> locations = new ArrayList<>();
+		try {
+			FileInputStream fis = new FileInputStream(f);
+			NBTTagCompound nbt = NBTCompressedStreamTools.a(fis);
+			short width = nbt.getShort("Width");
+			short height = nbt.getShort("Height");
+			short length = nbt.getShort("Length");
+			fis.close();
+			//paste
+			for(int x = 0; x < width; ++x) {
+				for(int y = 0; y < height; ++y) {
+					for(int z = 0; z < length; ++z) {
+						final Location l = new Location(loc.getWorld(), x + loc.getX(), y + loc.getY(), z + loc.getZ());
+						locations.add(l);
+					}
+				}
+			}
+		}catch(Exception e) {
+			e.printStackTrace();
+		}
+		return locations;
+	}
+
+	@SuppressWarnings("deprecation")
+	public static ItemStack getSpawnEgg(EntityType type, int amount) {
+		return new ItemStack(Material.getMaterial(type.name() + "_SPAWN_EGG"), amount);
+	}
+
+}


### PR DESCRIPTION
Notes:
- schematic loading is currently disabled
- to support 1.13 you have to use 1.12 material names (NOT NUMERIC IDS!) in your config/crate files
- this is just an hotfix, the plugin really needs a cleanup and some refactor in order to be compatible with future versions